### PR TITLE
bzr lightweight checkout

### DIFF
--- a/docker/setup_bansu_fedora_image.sh
+++ b/docker/setup_bansu_fedora_image.sh
@@ -22,7 +22,7 @@ download_all() {
     # do_wget https://ccp4forge.rc-harwell.ac.uk/ccp4/acedrg/-/archive/main/acedrg-${ACEDRG_VER}.tar.gz &&\
     # tar -xf acedrg-${ACEDRG_VER}.tar.gz
     echo Checking-out acedrg with breezy \(be patient, this may take a long time\)...
-    brz checkout https://fg.oisin.rc-harwell.ac.uk/anonscm/bzr/acedrg/trunk/ acedrg-${ACEDRG_VER} || exit 7
+    brz checkout --light https://fg.oisin.rc-harwell.ac.uk/anonscm/bzr/acedrg/trunk/ acedrg-${ACEDRG_VER} || exit 7
 
 
     # Libeigen


### PR DESCRIPTION
Using bzr checkout with the --light option is more efficient. 